### PR TITLE
Passthru wait time for receiving messages from sqs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
     // Identifiers
 
     group = 'com.blacklocus.queue-slayer'
-    version = '0.4.1-SNAPSHOT'
+    version = '0.5.1-SNAPSHOT'
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
     // Identifiers
 
     group = 'com.blacklocus.queue-slayer'
-    version = '0.5.1-SNAPSHOT'
+    version = '0.5.0-SNAPSHOT'
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/qs-aws/src/main/java/com/blacklocus/qs/aws/sqs/AmazonSQSMessageProvider.java
+++ b/qs-aws/src/main/java/com/blacklocus/qs/aws/sqs/AmazonSQSMessageProvider.java
@@ -40,14 +40,16 @@ public class AmazonSQSMessageProvider implements MessageProvider {
 
     private AmazonSQS sqs;
     private String queueUrl;
+    private int waitTimeSeconds;
 
     /**
      * Create a new MessageProvider instance.
      *
-     * @param sqs      AmazonSQS instance to use for communicating with AWS
-     * @param queueUrl target queue to pull Message instances from
+     * @param sqs             AmazonSQS instance to use for communicating with AWS
+     * @param queueUrl        target queue to pull Message instances from
+     * @param waitTimeSeconds to pass along to {@link ReceiveMessageRequest#withWaitTimeSeconds(Integer)}
      */
-    public AmazonSQSMessageProvider(AmazonSQS sqs, String queueUrl) {
+    public AmazonSQSMessageProvider(AmazonSQS sqs, String queueUrl, int waitTimeSeconds) {
         this.sqs = sqs;
         this.queueUrl = queueUrl;
     }
@@ -67,7 +69,8 @@ public class AmazonSQSMessageProvider implements MessageProvider {
             // receive messages from SQS
             ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl)
                     .withAttributeNames("SentTimestamp", "ApproximateReceiveCount")
-                    .withMaxNumberOfMessages(10);
+                    .withMaxNumberOfMessages(10)
+                    .withWaitTimeSeconds(waitTimeSeconds);
             List<com.amazonaws.services.sqs.model.Message> sqsMessages = sqs.receiveMessage(receiveMessageRequest).getMessages();
             return Lists.transform(sqsMessages, new Function<com.amazonaws.services.sqs.model.Message, Message>() {
                 @Override

--- a/qs-aws/src/test/java/com/blacklocus/qs/aws/AmazonSQSPrioritizedMessageProviderTest.java
+++ b/qs-aws/src/test/java/com/blacklocus/qs/aws/AmazonSQSPrioritizedMessageProviderTest.java
@@ -49,7 +49,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
         // return an empty list
         when(amazonSQS.listQueues(any(ListQueuesRequest.class))).thenReturn(new ListQueuesResult());
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 10 * 1000);
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, 10 * 1000);
         List<Message> empty = provider.next();
         Assert.assertEquals(0, empty.size());
 
@@ -68,7 +68,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
         when(amazonSQS.receiveMessage(any(ReceiveMessageRequest.class)))
                 .thenReturn(new ReceiveMessageResult().withMessages(newMessage("foo"), newMessage("foo"), newMessage("foo")));
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 60 * 1000);
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, 60 * 1000);
         List<Message> messages = provider.next();
         assertMessages(messages, 3, "foo");
 
@@ -121,7 +121,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
                 });
 
         // verify the order of next objects by counting the number of messages we return
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", TimeUnit.MINUTES.toMillis(30));
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, TimeUnit.MINUTES.toMillis(30));
 
         // for queues with messages, 1 receive returns messages, 1 receive returns none and removes the provider
         assertMessages(provider.next(), 3, "A");
@@ -177,7 +177,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
                 3 * intervalNs + 2                 // no update
         ).iterator();
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", TimeUnit.NANOSECONDS.toMillis(intervalNs)) {
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, TimeUnit.NANOSECONDS.toMillis(intervalNs)) {
             @Override
             public long currentNanoTime() {
                 return time.next();
@@ -233,7 +233,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
                     }
                 });
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 0)
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, 0)
                 .withInclude(new Predicate<String>() {
                     @Override
                     public boolean apply(String input) {
@@ -278,7 +278,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
                     }
                 });
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 0)
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, 0)
                 .withQueueComparator(new Comparator<String>() {
                     @Override
                     public int compare(String s1, String s2) {
@@ -324,7 +324,7 @@ public class AmazonSQSPrioritizedMessageProviderTest {
                     }
                 });
 
-        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 0)
+        AmazonSQSPrioritizedMessageProvider provider = new AmazonSQSPrioritizedMessageProvider(amazonSQS, "test", 1, 0)
                 .withQueueComparator(new Comparator<String>() {
                     @Override
                     public int compare(String s1, String s2) {


### PR DESCRIPTION
This adds wait time to the AmazonSQSMessageProvider. We found that sometimes SQS gets lazy and can frequently return 0 messages even though there are hundreds of thousands in the queue without a wait time.